### PR TITLE
feat: 將 17 層驗證系統轉換為 Claude Code Skills

### DIFF
--- a/.claude/skills/validate-17-layers/SKILL.md
+++ b/.claude/skills/validate-17-layers/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: validate-17-layers
+description: >
+  BlueMouse 17-Layer Code Validation System - Complete Python code quality validation
+  covering syntax, structure, function signatures, dependencies, types, logic, security,
+  and performance. Triggers: "validate", "17層驗證", "code quality", "v17"
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+user-invocable: true
+context: fork
+---
+
+# BlueMouse 17-Layer Validation Skill
+
+Complete code validation system from the BlueMouse AI Safety project. Validates Python code across 17 dimensions.
+
+## Two Ways to Use
+
+### 1. AI-Guided Validation (Recommended)
+
+When user requests code validation, follow the **17-Layer Checklist** below to analyze the code.
+
+### 2. Script Execution
+
+```bash
+python3 .claude/skills/validate-17-layers/validator.py myfile.py
+python3 .claude/skills/validate-17-layers/validator.py --json myfile.py
+```
+
+---
+
+# 17-Layer Validation Checklist
+
+When validating Python code, check ALL 17 layers in order:
+
+## Group 1: L1-L4 語法和結構驗證
+
+### L1: 基本語法檢查
+**What**: Code compiles without syntax errors
+**How**: `compile(code, '<string>', 'exec')`
+**Pass**: No SyntaxError
+**Fail**: Report syntax error location and message
+
+### L2: AST 結構檢查
+**What**: Code contains function or class definitions
+**How**: Parse AST, check for `FunctionDef` or `ClassDef` nodes
+**Pass**: At least one function or class defined
+**Fail**: "缺少函數或類定義"
+
+### L3: 縮進和格式檢查
+**What**: Proper indentation
+**How**: Check each line:
+- No tab characters (`\t`)
+- Leading spaces are multiples of 4
+**Pass**: All lines follow rules
+**Fail**: Report lines with issues (max 3)
+
+### L4: 命名規範檢查
+**What**: PEP 8 naming conventions
+**How**:
+- Functions: `^[a-z_][a-z0-9_]*$` (snake_case)
+- Classes: `^[A-Z][a-zA-Z0-9]*$` (PascalCase)
+**Pass**: All names follow conventions
+**Fail**: Report non-compliant names
+
+---
+
+## Group 2: L5-L8 函數簽名驗證
+
+### L5: 參數檢查
+**What**: Function has parameters (or matches spec if provided)
+**How**: Extract function arguments from AST
+**Pass**: Has parameters or matches spec
+**Fail**: "參數不匹配" with expected vs actual
+
+### L6: 返回值檢查
+**What**: Function has explicit return statement
+**How**: Check for `ast.Return` nodes in function body
+**Pass**: Has at least one `return`
+**Fail**: "函數缺少返回值"
+
+### L7: 類型提示檢查
+**What**: Type hints coverage ≥80% and has return type
+**How**:
+```
+coverage = params_with_annotations / total_params
+passed = coverage >= 0.8 AND has_return_type_hint
+```
+**Pass**: Coverage ≥80% with return type
+**Fail**: "類型提示不足: X%"
+
+### L8: 文檔字符串檢查
+**What**: Meaningful docstring (>10 characters)
+**How**: `ast.get_docstring(func)`
+**Pass**: Docstring length > 10
+**Fail**: "缺少或文檔字符串過短"
+
+---
+
+## Group 3: L9-L12 依賴關係驗證
+
+### L9: 導入檢查
+**What**: Count import statements
+**How**: Count `ast.Import` and `ast.ImportFrom` nodes
+**Pass**: Always (informational)
+**Output**: "找到 N 個導入語句"
+
+### L10: 標準庫檢查
+**What**: Identify stdlib usage
+**How**: Match imports against known stdlib:
+```
+{os, sys, json, re, datetime, typing, asyncio, time, math, hashlib}
+```
+**Pass**: Always (informational)
+**Output**: "精確識別出 N 個標準庫導入"
+
+### L11: 第三方庫檢查
+**What**: Identify third-party library usage
+**How**: Match imports against common packages:
+```
+{django, flask, fastapi, requests, numpy, pandas}
+```
+**Pass**: Always (informational)
+**Output**: "使用了 N 個第三方庫"
+
+### L12: 循環依賴檢查
+**What**: Detect risky relative imports
+**How**: Check `ast.ImportFrom` nodes where `level > 0`
+```python
+from ..module import x  # level=2, RISKY
+from .sibling import y  # level=1, RISKY
+```
+**Pass**: No relative imports
+**Fail**: "檢測到相對導入，可能存在循環依賴風險"
+
+---
+
+## Group 4: L13-L17 類型和邏輯驗證
+
+### L13: 類型一致性檢查
+**What**: All functions have ≥70% type hint coverage
+**How**: Scan all functions, calculate overall coverage
+**Pass**: Coverage ≥70%
+**Fail**: "函數類型提示覆蓋率: X%"
+
+### L14: 邏輯完整性檢查
+**What**: Code has control flow structures
+**How**: Check for `ast.If`, `ast.For`, `ast.While`
+**Pass**: Always (informational)
+**Output**: "邏輯結構完整" or "邏輯結構簡單"
+
+### L15: 錯誤處理檢查 ⚠️ ANTI-PATTERN DETECTION
+**What**: No empty try-except blocks
+**How**: Find `ast.Try` nodes, check handlers:
+```python
+# ❌ FAIL: Empty handler
+except:
+    pass
+
+# ❌ FAIL: Only pass
+except Exception as e:
+    pass
+
+# ✅ PASS: Actual handling
+except Exception as e:
+    logger.error(e)
+    raise
+```
+**Pass**: Has try-except AND no empty/pass-only handlers
+**Fail**: "發現 N 個空的或只有 pass 的錯誤處理塊 (Anti-pattern)"
+
+### L16: 安全性檢查 🔒 SECURITY SCAN
+**What**: No dangerous functions or hardcoded secrets
+**How**:
+1. Dangerous functions:
+   - `eval()` - arbitrary code execution
+   - `exec()` - arbitrary code execution
+   - `pickle` - deserialization vulnerability
+2. Hardcoded secrets (regex):
+   - `api_key\s*=\s*[\'"][^\s*]{10,}[\'"]`
+   - `password\s*=\s*[\'"][^\s*]{8,}[\'"]`
+**Pass**: No dangerous functions AND no hardcoded secrets
+**Fail**: "發現 N 個潛在安全性問題" with list
+
+### L17: 性能檢查 ⚡ COMPLEXITY ANALYSIS
+**What**: No deeply nested loops (≥3 levels)
+**How**: Calculate maximum loop nesting depth
+```python
+# ❌ FAIL: 3-level nesting
+for i in range(n):      # Level 1
+    for j in range(n):  # Level 2
+        for k in range(n):  # Level 3 - TOO DEEP
+            pass
+
+# ✅ PASS: 2-level nesting
+for i in range(n):      # Level 1
+    for j in range(n):  # Level 2
+        pass
+```
+**Pass**: max_depth < 3
+**Fail**: "檢測到過深的循環嵌套 (Depth: N)，建議優化算法"
+
+---
+
+## Output Format
+
+When reporting results, use this format:
+
+```
+============================================================
+BlueMouse 17-Layer Validation Report
+============================================================
+
+Status: ✅ PASSED / ❌ FAILED
+Quality Score: X/100
+Layers Passed: N/17
+
+------------------------------------------------------------
+Layer Results:
+------------------------------------------------------------
+
+L1-L4: 語法和結構:
+  ✅/❌ L1: 基本語法檢查 - [message]
+  ✅/❌ L2: AST 結構檢查 - [message]
+  ✅/❌ L3: 縮進和格式檢查 - [message]
+  ✅/❌ L4: 命名規範檢查 - [message]
+
+L5-L8: 函數簽名:
+  ✅/❌ L5: 參數檢查 - [message]
+  ✅/❌ L6: 返回值檢查 - [message]
+  ✅/❌ L7: 類型提示檢查 - [message]
+  ✅/❌ L8: 文檔字符串檢查 - [message]
+
+L9-L12: 依賴關係:
+  ✅/❌ L9: 導入檢查 - [message]
+  ✅/❌ L10: 標準庫檢查 - [message]
+  ✅/❌ L11: 第三方庫檢查 - [message]
+  ✅/❌ L12: 循環依賴檢查 - [message]
+
+L13-L17: 類型和邏輯:
+  ✅/❌ L13: 類型一致性檢查 - [message]
+  ✅/❌ L14: 邏輯完整性檢查 - [message]
+  ✅/❌ L15: 錯誤處理檢查 - [message]
+  ✅/❌ L16: 安全性檢查 - [message]
+  ✅/❌ L17: 性能檢查 - [message]
+
+Suggestions (top 5 failed layers):
+  1. [L#] ([name]): [message]
+  ...
+============================================================
+```
+
+## Quality Score Calculation
+
+```
+quality_score = (passed_layers / 17) * 100
+```
+
+---
+
+## Related Skills
+
+| Skill | Layers | 用途 |
+|-------|--------|------|
+| `/validate-17-layers` | L1-L17 | 完整驗證 |
+| `/validate-syntax` | L1-L4 | 語法和結構 |
+| `/validate-signature` | L5-L8 | 函數簽名 |
+| `/validate-dependencies` | L9-L12 | 依賴關係 |
+| `/validate-logic` | L13-L17 | 類型和邏輯 |
+
+---
+
+*Part of BlueMouse v6.6 AI Safety Layer*

--- a/.claude/skills/validate-17-layers/validator.py
+++ b/.claude/skills/validate-17-layers/validator.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""
+BlueMouse 17-Layer Code Validation System
+獨立版本 - 可作為 Claude Code Skill 使用
+
+用法:
+    python validator.py <file.py>
+    python validator.py --code "def foo(): pass"
+    python validator.py --stdin < file.py
+"""
+
+import ast
+import re
+import sys
+import json
+import argparse
+from typing import Dict, List, Any, Optional
+
+
+# ============================================================================
+# 主入口函數
+# ============================================================================
+
+def validate_code_17_layers(code: str, node_id: str = "unknown", spec: Optional[Dict] = None) -> Dict[str, Any]:
+    """
+    17 層完整代碼驗證
+
+    驗證層級:
+    L1-L4:   語法和結構驗證
+    L5-L8:   函數簽名驗證
+    L9-L12:  依賴關係驗證
+    L13-L17: 類型和邏輯驗證
+
+    Args:
+        code: 要驗證的代碼
+        node_id: 節點 ID
+        spec: 節點規格 (可選)
+
+    Returns:
+        驗證結果字典
+    """
+    results = []
+
+    # L1-L4: 語法和結構驗證
+    results.extend(validate_syntax_and_structure(code))
+
+    # L5-L8: 函數簽名驗證
+    results.extend(validate_function_signature(code, spec))
+
+    # L9-L12: 依賴關係驗證
+    results.extend(validate_dependencies(code, spec))
+
+    # L13-L17: 類型和邏輯驗證
+    results.extend(validate_types_and_logic(code, spec))
+
+    # 計算總體結果
+    passed = all(r["passed"] for r in results)
+    quality_score = calculate_quality_score(results)
+
+    return {
+        "passed": passed,
+        "layers": results,
+        "quality_score": quality_score,
+        "total_layers": len(results),
+        "passed_layers": sum(1 for r in results if r["passed"]),
+        "suggestions": generate_suggestions(results)
+    }
+
+
+# ============================================================================
+# L1-L4: 語法和結構驗證
+# ============================================================================
+
+def validate_syntax_and_structure(code: str) -> List[Dict]:
+    """L1-L4: 語法和結構驗證"""
+    results = []
+    results.append(validate_l1_basic_syntax(code))
+    results.append(validate_l2_ast_structure(code))
+    results.append(validate_l3_indentation(code))
+    results.append(validate_l4_naming_convention(code))
+    return results
+
+
+def validate_l1_basic_syntax(code: str) -> Dict:
+    """L1: 基本語法檢查"""
+    try:
+        compile(code, '<string>', 'exec')
+        return {
+            "layer": 1,
+            "name": "基本語法檢查",
+            "passed": True,
+            "message": "語法正確"
+        }
+    except SyntaxError as e:
+        return {
+            "layer": 1,
+            "name": "基本語法檢查",
+            "passed": False,
+            "message": f"語法錯誤: {str(e)}",
+            "error": str(e)
+        }
+
+
+def validate_l2_ast_structure(code: str) -> Dict:
+    """L2: AST 結構檢查"""
+    try:
+        tree = ast.parse(code)
+        has_definition = any(isinstance(node, (ast.FunctionDef, ast.ClassDef))
+                            for node in ast.walk(tree))
+
+        if has_definition:
+            return {
+                "layer": 2,
+                "name": "AST 結構檢查",
+                "passed": True,
+                "message": "AST 結構完整"
+            }
+        else:
+            return {
+                "layer": 2,
+                "name": "AST 結構檢查",
+                "passed": False,
+                "message": "缺少函數或類定義"
+            }
+    except Exception as e:
+        return {
+            "layer": 2,
+            "name": "AST 結構檢查",
+            "passed": False,
+            "message": f"AST 解析失敗: {str(e)}"
+        }
+
+
+def validate_l3_indentation(code: str) -> Dict:
+    """L3: 縮進和格式檢查"""
+    lines = code.split('\n')
+    issues = []
+
+    for i, line in enumerate(lines, 1):
+        if '\t' in line:
+            issues.append(f"Line {i}: 使用 Tab 而非空格")
+
+        if line and not line.lstrip():
+            continue
+        leading_spaces = len(line) - len(line.lstrip())
+        if leading_spaces % 4 != 0:
+            issues.append(f"Line {i}: 縮進不是 4 的倍數")
+
+    if not issues:
+        return {
+            "layer": 3,
+            "name": "縮進和格式檢查",
+            "passed": True,
+            "message": "縮進格式正確"
+        }
+    else:
+        return {
+            "layer": 3,
+            "name": "縮進和格式檢查",
+            "passed": False,
+            "message": f"發現 {len(issues)} 個格式問題",
+            "issues": issues[:3]
+        }
+
+
+def validate_l4_naming_convention(code: str) -> Dict:
+    """L4: 命名規範檢查 (PEP 8)"""
+    try:
+        tree = ast.parse(code)
+        issues = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                if not re.match(r'^[a-z_][a-z0-9_]*$', node.name):
+                    issues.append(f"函數名 '{node.name}' 不符合 snake_case")
+
+            if isinstance(node, ast.ClassDef):
+                if not re.match(r'^[A-Z][a-zA-Z0-9]*$', node.name):
+                    issues.append(f"類名 '{node.name}' 不符合 PascalCase")
+
+        if not issues:
+            return {
+                "layer": 4,
+                "name": "命名規範檢查",
+                "passed": True,
+                "message": "命名符合 PEP 8"
+            }
+        else:
+            return {
+                "layer": 4,
+                "name": "命名規範檢查",
+                "passed": len(issues) == 0,
+                "message": f"發現 {len(issues)} 個命名問題",
+                "issues": issues[:3]
+            }
+    except Exception as e:
+        return {
+            "layer": 4,
+            "name": "命名規範檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+# ============================================================================
+# L5-L8: 函數簽名驗證
+# ============================================================================
+
+def validate_function_signature(code: str, spec: Optional[Dict]) -> List[Dict]:
+    """L5-L8: 函數簽名驗證"""
+    results = []
+    results.append(validate_l5_parameters(code, spec))
+    results.append(validate_l6_return_value(code, spec))
+    results.append(validate_l7_type_hints(code))
+    results.append(validate_l8_docstring(code))
+    return results
+
+
+def validate_l5_parameters(code: str, spec: Optional[Dict]) -> Dict:
+    """L5: 參數檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 5,
+                "name": "參數檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+
+        if spec and 'inputs' in spec:
+            expected_params = set(spec['inputs'])
+            actual_params = set(arg.arg for arg in func.args.args)
+
+            if expected_params == actual_params:
+                return {
+                    "layer": 5,
+                    "name": "參數檢查",
+                    "passed": True,
+                    "message": "參數與規格匹配"
+                }
+            else:
+                return {
+                    "layer": 5,
+                    "name": "參數檢查",
+                    "passed": False,
+                    "message": f"參數不匹配: 期望 {expected_params}, 實際 {actual_params}"
+                }
+        else:
+            return {
+                "layer": 5,
+                "name": "參數檢查",
+                "passed": True,
+                "message": f"函數有 {len(func.args.args)} 個參數"
+            }
+    except Exception as e:
+        return {
+            "layer": 5,
+            "name": "參數檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l6_return_value(code: str, spec: Optional[Dict]) -> Dict:
+    """L6: 返回值檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        has_return = any(isinstance(node, ast.Return) for node in ast.walk(func))
+
+        if has_return:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": True,
+                "message": "函數有返回值"
+            }
+        else:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": False,
+                "message": "函數缺少返回值"
+            }
+    except Exception as e:
+        return {
+            "layer": 6,
+            "name": "返回值檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l7_type_hints(code: str) -> Dict:
+    """L7: 類型提示檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        params_with_hints = sum(1 for arg in func.args.args if arg.annotation)
+        total_params = len(func.args.args)
+        has_return_hint = func.returns is not None
+
+        if total_params > 0:
+            hint_coverage = params_with_hints / total_params
+        else:
+            hint_coverage = 1.0 if has_return_hint else 0.0
+
+        if hint_coverage >= 0.8 and has_return_hint:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": True,
+                "message": f"類型提示覆蓋率: {hint_coverage*100:.0f}%"
+            }
+        else:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": False,
+                "message": f"類型提示不足: {hint_coverage*100:.0f}%"
+            }
+    except Exception as e:
+        return {
+            "layer": 7,
+            "name": "類型提示檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l8_docstring(code: str) -> Dict:
+    """L8: 文檔字符串檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        docstring = ast.get_docstring(func)
+
+        if docstring and len(docstring) > 10:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": True,
+                "message": f"有完整文檔字符串 ({len(docstring)} 字符)"
+            }
+        else:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": False,
+                "message": "缺少或文檔字符串過短"
+            }
+    except Exception as e:
+        return {
+            "layer": 8,
+            "name": "文檔字符串檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+# ============================================================================
+# L9-L12: 依賴關係驗證
+# ============================================================================
+
+def validate_dependencies(code: str, spec: Optional[Dict]) -> List[Dict]:
+    """L9-L12: 依賴關係驗證"""
+    results = []
+    results.append(validate_l9_imports(code))
+    results.append(validate_l10_stdlib(code))
+    results.append(validate_l11_third_party(code))
+    results.append(validate_l12_circular_deps(code))
+    return results
+
+
+def validate_l9_imports(code: str) -> Dict:
+    """L9: 導入檢查"""
+    try:
+        tree = ast.parse(code)
+        imports = [node for node in ast.walk(tree)
+                  if isinstance(node, (ast.Import, ast.ImportFrom))]
+
+        return {
+            "layer": 9,
+            "name": "導入檢查",
+            "passed": True,
+            "message": f"找到 {len(imports)} 個導入語句"
+        }
+    except Exception as e:
+        return {
+            "layer": 9,
+            "name": "導入檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l10_stdlib(code: str) -> Dict:
+    """L10: 標準庫檢查 (AST 級別)"""
+    try:
+        tree = ast.parse(code)
+        import_names = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    import_names.append(n.name.split('.')[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    import_names.append(node.module.split('.')[0])
+
+        stdlib = {'os', 'sys', 'json', 're', 'datetime', 'typing', 'asyncio', 'time', 'math', 'hashlib'}
+        used = [name for name in import_names if name in stdlib]
+
+        return {
+            "layer": 10,
+            "name": "標準庫檢查",
+            "passed": True,
+            "message": f"精確識別出 {len(set(used))} 個標準庫導入"
+        }
+    except Exception as e:
+        return {"layer": 10, "name": "標準庫檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+def validate_l11_third_party(code: str) -> Dict:
+    """L11: 第三方庫檢查"""
+    third_party = {'django', 'flask', 'fastapi', 'requests', 'numpy', 'pandas'}
+
+    used_third_party = []
+    for module in third_party:
+        if f"import {module}" in code or f"from {module}" in code:
+            used_third_party.append(module)
+
+    return {
+        "layer": 11,
+        "name": "第三方庫檢查",
+        "passed": True,
+        "message": f"使用了 {len(used_third_party)} 個第三方庫" if used_third_party else "未使用第三方庫"
+    }
+
+
+def validate_l12_circular_deps(code: str) -> Dict:
+    """L12: 循環依賴檢查 (AST 探測)"""
+    try:
+        tree = ast.parse(code)
+        has_relative = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level > 0:
+                has_relative = True
+                break
+
+        return {
+            "layer": 12,
+            "name": "循環依賴檢查",
+            "passed": not has_relative,
+            "message": "通過 (未檢測到危險的相對導入)" if not has_relative else "檢測到相對導入，可能存在循環依賴風險"
+        }
+    except Exception as e:
+        return {"layer": 12, "name": "循環依賴檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+# ============================================================================
+# L13-L17: 類型和邏輯驗證
+# ============================================================================
+
+def validate_types_and_logic(code: str, spec: Optional[Dict]) -> List[Dict]:
+    """L13-L17: 類型和邏輯驗證"""
+    results = []
+    results.append(validate_l13_type_consistency(code))
+    results.append(validate_l14_logic_completeness(code))
+    results.append(validate_l15_error_handling(code))
+    results.append(validate_l16_security(code))
+    results.append(validate_l17_performance(code))
+    return results
+
+
+def validate_l13_type_consistency(code: str) -> Dict:
+    """L13: 類型一致性檢查 (AST 深度掃描)"""
+    try:
+        tree = ast.parse(code)
+        funcs = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+        if not funcs:
+            return {"layer": 13, "name": "類型一致性檢查", "passed": True, "message": "無函數需檢查"}
+
+        total = len(funcs)
+        with_hints = sum(1 for f in funcs if f.returns or any(arg.annotation for arg in f.args.args))
+
+        passed = (with_hints / total) >= 0.7
+        return {
+            "layer": 13,
+            "name": "類型一致性檢查",
+            "passed": passed,
+            "message": f"函數類型提示覆蓋率: {int(with_hints/total*100)}%"
+        }
+    except Exception as e:
+        return {"layer": 13, "name": "類型一致性檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+def validate_l14_logic_completeness(code: str) -> Dict:
+    """L14: 邏輯完整性檢查"""
+    try:
+        tree = ast.parse(code)
+        has_branches = any(isinstance(node, (ast.If, ast.For, ast.While))
+                          for node in ast.walk(tree))
+
+        return {
+            "layer": 14,
+            "name": "邏輯完整性檢查",
+            "passed": True,
+            "message": "邏輯結構完整" if has_branches else "邏輯結構簡單"
+        }
+    except Exception as e:
+        return {
+            "layer": 14,
+            "name": "邏輯完整性檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l15_error_handling(code: str) -> Dict:
+    """L15: 錯誤處理檢查 (深度驗證)"""
+    try:
+        tree = ast.parse(code)
+        try_nodes = [node for node in ast.walk(tree) if isinstance(node, ast.Try)]
+
+        if not try_nodes:
+            return {
+                "layer": 15,
+                "name": "錯誤處理檢查",
+                "passed": False,
+                "message": "建議添加 try-except 錯誤處理塊"
+            }
+
+        bad_handlers = 0
+        for node in try_nodes:
+            for handler in node.handlers:
+                if not handler.body:
+                    bad_handlers += 1
+                elif len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass):
+                    bad_handlers += 1
+
+        if bad_handlers > 0:
+            return {
+                "layer": 15,
+                "name": "錯誤處理檢查",
+                "passed": False,
+                "message": f"發現 {bad_handlers} 個空的或只有 pass 的錯誤處理塊 (Anti-pattern)"
+            }
+
+        return {
+            "layer": 15,
+            "name": "錯誤處理檢查",
+            "passed": True,
+            "message": f"檢測到 {len(try_nodes)} 個有效錯誤處理塊"
+        }
+    except Exception as e:
+        return {"layer": 15, "name": "錯誤處理檢查", "passed": False, "message": f"解析失敗: {str(e)}"}
+
+
+def validate_l16_security(code: str) -> Dict:
+    """L16: 安全性檢查 (深度分析)"""
+    try:
+        tree = ast.parse(code)
+        issues = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func_name = ""
+                if isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    func_name = node.func.attr
+
+                if func_name in ['eval', 'exec', 'pickle']:
+                    issues.append(f"使用了危險函數: {func_name}")
+
+        secret_patterns = [r'api_key\s*=\s*[\'"][^\s*]{10,}[\'"]', r'password\s*=\s*[\'"][^\s*]{8,}[\'"]']
+        for pattern in secret_patterns:
+            if re.search(pattern, code, re.IGNORECASE):
+                issues.append("檢測到可能的寫死密鑰或密碼")
+                break
+
+        return {
+            "layer": 16,
+            "name": "安全性檢查",
+            "passed": len(issues) == 0,
+            "message": "未發現明顯安全問題" if not issues else f"發現 {len(issues)} 個潛在安全性問題",
+            "issues": issues if issues else None
+        }
+    except Exception as e:
+        return {"layer": 16, "name": "安全性檢查", "passed": False, "message": f"分析失敗: {str(e)}"}
+
+
+def validate_l17_performance(code: str) -> Dict:
+    """L17: 性能檢查 (深度循環分析)"""
+    try:
+        tree = ast.parse(code)
+        max_depth = 0
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.For, ast.While)):
+                depth = 1
+                curr = node
+                while any(isinstance(child, (ast.For, ast.While)) for child in ast.iter_child_nodes(curr)):
+                    depth += 1
+                    for child in ast.iter_child_nodes(curr):
+                        if isinstance(child, (ast.For, ast.While)):
+                            curr = child
+                            break
+                    if depth > 5:
+                        break
+                max_depth = max(max_depth, depth)
+
+        if max_depth >= 3:
+            return {
+                "layer": 17,
+                "name": "性能檢查",
+                "passed": False,
+                "message": f"檢測到過深的循環嵌套 (Depth: {max_depth})，建議優化算法"
+            }
+
+        return {
+            "layer": 17,
+            "name": "性能檢查",
+            "passed": True,
+            "message": f"最高循環嵌套深度: {max_depth} (符合效能規範)"
+        }
+    except Exception as e:
+        return {"layer": 17, "name": "性能檢查", "passed": False, "message": f"分析失敗: {str(e)}"}
+
+
+# ============================================================================
+# 輔助函數
+# ============================================================================
+
+def calculate_quality_score(results: List[Dict]) -> int:
+    """計算質量評分 (0-100)"""
+    if not results:
+        return 0
+
+    passed_count = sum(1 for r in results if r["passed"])
+    total_count = len(results)
+
+    return int((passed_count / total_count) * 100)
+
+
+def generate_suggestions(results: List[Dict]) -> List[str]:
+    """生成改進建議"""
+    suggestions = []
+
+    for result in results:
+        if not result["passed"]:
+            layer = result["layer"]
+            name = result["name"]
+            message = result.get("message", "")
+
+            suggestions.append(f"L{layer} ({name}): {message}")
+
+    return suggestions[:5]
+
+
+def print_report(result: Dict, verbose: bool = False):
+    """打印驗證報告"""
+    print(f"\n{'='*60}")
+    print(f"BlueMouse 17-Layer Validation Report")
+    print(f"{'='*60}")
+
+    status = "✅ PASSED" if result['passed'] else "❌ FAILED"
+    print(f"\nStatus: {status}")
+    print(f"Quality Score: {result['quality_score']}/100")
+    print(f"Layers Passed: {result['passed_layers']}/{result['total_layers']}")
+
+    print(f"\n{'-'*60}")
+    print("Layer Results:")
+    print(f"{'-'*60}")
+
+    groups = [
+        ("L1-L4: 語法和結構", [1, 2, 3, 4]),
+        ("L5-L8: 函數簽名", [5, 6, 7, 8]),
+        ("L9-L12: 依賴關係", [9, 10, 11, 12]),
+        ("L13-L17: 類型和邏輯", [13, 14, 15, 16, 17])
+    ]
+
+    for group_name, layers in groups:
+        print(f"\n{group_name}:")
+        for layer in result['layers']:
+            if layer['layer'] in layers:
+                icon = "✅" if layer['passed'] else "❌"
+                print(f"  {icon} L{layer['layer']}: {layer['name']} - {layer['message']}")
+                if verbose and 'issues' in layer and layer['issues']:
+                    for issue in layer['issues']:
+                        print(f"      → {issue}")
+
+    if result['suggestions']:
+        print(f"\n{'-'*60}")
+        print("Suggestions:")
+        print(f"{'-'*60}")
+        for i, suggestion in enumerate(result['suggestions'], 1):
+            print(f"  {i}. {suggestion}")
+
+    print(f"\n{'='*60}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='BlueMouse 17-Layer Code Validation System',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python validator.py myfile.py
+  python validator.py --code "def foo(): pass"
+  cat myfile.py | python validator.py --stdin
+  python validator.py myfile.py --json
+        '''
+    )
+    parser.add_argument('file', nargs='?', help='Python file to validate')
+    parser.add_argument('--code', '-c', help='Code string to validate')
+    parser.add_argument('--stdin', action='store_true', help='Read code from stdin')
+    parser.add_argument('--json', '-j', action='store_true', help='Output as JSON')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+    parser.add_argument('--spec', '-s', help='JSON spec file for validation')
+
+    args = parser.parse_args()
+
+    # 獲取代碼
+    code = None
+    if args.stdin:
+        code = sys.stdin.read()
+    elif args.code:
+        code = args.code
+    elif args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                code = f.read()
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    # 讀取 spec
+    spec = None
+    if args.spec:
+        try:
+            with open(args.spec, 'r', encoding='utf-8') as f:
+                spec = json.load(f)
+        except Exception as e:
+            print(f"Warning: Could not load spec file: {e}", file=sys.stderr)
+
+    # 執行驗證
+    result = validate_code_17_layers(code, "cli", spec)
+
+    # 輸出結果
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print_report(result, verbose=args.verbose)
+
+    # 返回碼
+    sys.exit(0 if result['passed'] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/validate-dependencies/SKILL.md
+++ b/.claude/skills/validate-dependencies/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: validate-dependencies
+description: >
+  L9-L12 依賴關係驗證 - 檢查導入語句、標準庫、第三方庫、循環依賴。
+  BlueMouse 17-Layer Validation Group 3。
+  Triggers: "dependencies", "imports", "依賴檢查", "circular"
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+user-invocable: true
+context: fork
+---
+
+# Validate Dependencies Skill (L9-L12)
+
+BlueMouse 17-Layer Validation System - Group 3: 依賴關係驗證
+
+## Two Ways to Use
+
+### 1. AI-Guided Validation
+Follow the checklist below to analyze code.
+
+### 2. Script Execution
+```bash
+python3 .claude/skills/validate-dependencies/validator.py myfile.py
+python3 .claude/skills/validate-dependencies/validator.py --verbose myfile.py
+```
+
+---
+
+# L9-L12 Validation Checklist
+
+## L9: 導入檢查 (Informational)
+
+**What**: Count import statements in code
+
+**How**:
+```python
+imports = [
+    node for node in ast.walk(tree)
+    if isinstance(node, (ast.Import, ast.ImportFrom))
+]
+```
+
+**Output**: `"找到 N 個導入語句"`
+**Pass**: Always (informational only)
+
+---
+
+## L10: 標準庫檢查 (Informational)
+
+**What**: Identify Python standard library usage
+
+**Known Stdlib**:
+```python
+stdlib = {
+    'os', 'sys', 'json', 're', 'datetime', 'typing',
+    'asyncio', 'time', 'math', 'hashlib', 'collections',
+    'functools', 'itertools', 'pathlib', 'subprocess',
+    'threading', 'multiprocessing', 'logging', 'unittest',
+    'argparse', 'copy', 'io', 'tempfile'
+}
+```
+
+**How**:
+```python
+import_names = []
+for node in ast.walk(tree):
+    if isinstance(node, ast.Import):
+        for n in node.names:
+            import_names.append(n.name.split('.')[0])
+    elif isinstance(node, ast.ImportFrom):
+        if node.module:
+            import_names.append(node.module.split('.')[0])
+
+used = [name for name in import_names if name in stdlib]
+```
+
+**Output**: `"精確識別出 N 個標準庫導入"`
+**Pass**: Always (informational only)
+
+---
+
+## L11: 第三方庫檢查 (Informational)
+
+**What**: Identify common third-party library usage
+
+**Known Third-Party**:
+```python
+third_party = {
+    'django', 'flask', 'fastapi', 'requests', 'numpy',
+    'pandas', 'pytest', 'aiohttp', 'sqlalchemy', 'pydantic',
+    'httpx', 'redis', 'celery', 'boto3', 'tensorflow',
+    'torch', 'scikit-learn'
+}
+```
+
+**How**:
+```python
+used = []
+for module in third_party:
+    if f"import {module}" in code or f"from {module}" in code:
+        used.append(module)
+```
+
+**Output**:
+- Found: `"使用了 N 個第三方庫"`
+- None: `"未使用第三方庫"`
+
+**Pass**: Always (informational only)
+
+---
+
+## L12: 循環依賴檢查 ⚠️
+
+**What**: Detect risky relative imports that may cause circular dependencies
+
+**How**:
+```python
+for node in ast.walk(tree):
+    if isinstance(node, ast.ImportFrom) and node.level > 0:
+        has_relative = True
+```
+
+**Import Level Explanation**:
+| Code | Level | Risk |
+|------|-------|------|
+| `import os` | 0 | ✅ Safe |
+| `from module import x` | 0 | ✅ Safe |
+| `from .sibling import x` | 1 | ⚠️ Risky |
+| `from ..parent import x` | 2 | ⚠️ Risky |
+
+**Pass**: No relative imports → `"通過 (未檢測到危險的相對導入)"`
+**Fail**: `"檢測到相對導入，可能存在循環依賴風險"`
+
+**Examples**:
+```python
+# ✅ PASS: Absolute imports only
+import os
+from package.module import func
+from typing import Dict
+
+# ❌ FAIL: Relative imports
+from .sibling import helper  # level=1
+from ..parent import config  # level=2
+```
+
+**Why Relative Imports Are Risky**:
+```
+project/
+├── package_a/
+│   └── module_a.py  # from ..package_b import func_b
+└── package_b/
+    └── module_b.py  # from ..package_a import func_a
+                     # ❌ Circular dependency!
+```
+
+---
+
+## Output Format
+
+```
+==================================================
+L9-L12: 依賴關係驗證
+==================================================
+
+Status: ✅ PASSED / ❌ FAILED
+Score: X/100 (N/4 layers)
+
+✅ L9: 導入檢查 - 找到 N 個導入語句
+✅ L10: 標準庫檢查 - 精確識別出 N 個標準庫導入
+✅ L11: 第三方庫檢查 - 使用了 N 個第三方庫
+✅/❌ L12: 循環依賴檢查 - [message]
+
+[Verbose mode shows detected libraries]
+```
+
+---
+
+## Related Skills
+
+| Skill | Layers |
+|-------|--------|
+| `/validate-17-layers` | L1-L17 (完整) |
+| `/validate-syntax` | L1-L4 |
+| `/validate-signature` | L5-L8 |
+| `/validate-dependencies` | **L9-L12** |
+| `/validate-logic` | L13-L17 |
+
+---
+
+*Part of BlueMouse 17-Layer Validation System*

--- a/.claude/skills/validate-dependencies/validator.py
+++ b/.claude/skills/validate-dependencies/validator.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+BlueMouse L9-L12: 依賴關係驗證
+獨立版本 - 可作為 Claude Code Skill 使用
+
+用法:
+    python validator.py <file.py>
+    python validator.py --code "import os"
+"""
+
+import ast
+import sys
+import json
+import argparse
+from typing import Dict, List, Optional
+
+
+def validate_dependencies(code: str, spec: Optional[Dict] = None) -> List[Dict]:
+    """L9-L12: 依賴關係驗證"""
+    results = []
+    results.append(validate_l9_imports(code))
+    results.append(validate_l10_stdlib(code))
+    results.append(validate_l11_third_party(code))
+    results.append(validate_l12_circular_deps(code))
+    return results
+
+
+def validate_l9_imports(code: str) -> Dict:
+    """L9: 導入檢查"""
+    try:
+        tree = ast.parse(code)
+        imports = [node for node in ast.walk(tree)
+                  if isinstance(node, (ast.Import, ast.ImportFrom))]
+
+        return {
+            "layer": 9,
+            "name": "導入檢查",
+            "passed": True,
+            "message": f"找到 {len(imports)} 個導入語句"
+        }
+    except Exception as e:
+        return {
+            "layer": 9,
+            "name": "導入檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l10_stdlib(code: str) -> Dict:
+    """L10: 標準庫檢查 (AST 級別)"""
+    try:
+        tree = ast.parse(code)
+        import_names = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    import_names.append(n.name.split('.')[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    import_names.append(node.module.split('.')[0])
+
+        stdlib = {'os', 'sys', 'json', 're', 'datetime', 'typing', 'asyncio', 'time', 'math', 'hashlib',
+                  'collections', 'functools', 'itertools', 'pathlib', 'subprocess', 'threading',
+                  'multiprocessing', 'logging', 'unittest', 'argparse', 'copy', 'io', 'tempfile'}
+        used = [name for name in import_names if name in stdlib]
+
+        return {
+            "layer": 10,
+            "name": "標準庫檢查",
+            "passed": True,
+            "message": f"精確識別出 {len(set(used))} 個標準庫導入",
+            "stdlib_used": list(set(used))
+        }
+    except Exception as e:
+        return {"layer": 10, "name": "標準庫檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+def validate_l11_third_party(code: str) -> Dict:
+    """L11: 第三方庫檢查"""
+    third_party = {'django', 'flask', 'fastapi', 'requests', 'numpy', 'pandas',
+                   'pytest', 'aiohttp', 'sqlalchemy', 'pydantic', 'httpx', 'redis',
+                   'celery', 'boto3', 'tensorflow', 'torch', 'scikit-learn'}
+
+    used_third_party = []
+    for module in third_party:
+        if f"import {module}" in code or f"from {module}" in code:
+            used_third_party.append(module)
+
+    return {
+        "layer": 11,
+        "name": "第三方庫檢查",
+        "passed": True,
+        "message": f"使用了 {len(used_third_party)} 個第三方庫" if used_third_party else "未使用第三方庫",
+        "third_party_used": used_third_party
+    }
+
+
+def validate_l12_circular_deps(code: str) -> Dict:
+    """L12: 循環依賴檢查 (AST 探測)"""
+    try:
+        tree = ast.parse(code)
+        relative_imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level > 0:
+                module = node.module or ""
+                relative_imports.append(f"{'.' * node.level}{module}")
+
+        if relative_imports:
+            return {
+                "layer": 12,
+                "name": "循環依賴檢查",
+                "passed": False,
+                "message": f"檢測到 {len(relative_imports)} 個相對導入，可能存在循環依賴風險",
+                "relative_imports": relative_imports
+            }
+        else:
+            return {
+                "layer": 12,
+                "name": "循環依賴檢查",
+                "passed": True,
+                "message": "通過 (未檢測到危險的相對導入)"
+            }
+    except Exception as e:
+        return {"layer": 12, "name": "循環依賴檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+def print_report(results: List[Dict], verbose: bool = False):
+    """打印驗證報告"""
+    print(f"\n{'='*50}")
+    print("L9-L12: 依賴關係驗證")
+    print(f"{'='*50}\n")
+
+    passed_count = sum(1 for r in results if r["passed"])
+    total_count = len(results)
+    score = int((passed_count / total_count) * 100)
+
+    status = "✅ PASSED" if passed_count == total_count else "❌ FAILED"
+    print(f"Status: {status}")
+    print(f"Score: {score}/100 ({passed_count}/{total_count} layers)\n")
+
+    for layer in results:
+        icon = "✅" if layer['passed'] else "❌"
+        print(f"{icon} L{layer['layer']}: {layer['name']} - {layer['message']}")
+        if verbose:
+            if 'stdlib_used' in layer and layer['stdlib_used']:
+                print(f"    標準庫: {', '.join(layer['stdlib_used'])}")
+            if 'third_party_used' in layer and layer['third_party_used']:
+                print(f"    第三方: {', '.join(layer['third_party_used'])}")
+            if 'relative_imports' in layer and layer['relative_imports']:
+                print(f"    相對導入: {', '.join(layer['relative_imports'])}")
+
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='BlueMouse L9-L12: 依賴關係驗證')
+    parser.add_argument('file', nargs='?', help='Python file to validate')
+    parser.add_argument('--code', '-c', help='Code string to validate')
+    parser.add_argument('--stdin', action='store_true', help='Read code from stdin')
+    parser.add_argument('--json', '-j', action='store_true', help='Output as JSON')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+
+    args = parser.parse_args()
+
+    code = None
+    if args.stdin:
+        code = sys.stdin.read()
+    elif args.code:
+        code = args.code
+    elif args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                code = f.read()
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    results = validate_dependencies(code)
+
+    if args.json:
+        output = {
+            "group": "L9-L12: 依賴關係驗證",
+            "passed": all(r["passed"] for r in results),
+            "layers": results,
+            "score": int(sum(1 for r in results if r["passed"]) / len(results) * 100)
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+    else:
+        print_report(results, verbose=args.verbose)
+
+    sys.exit(0 if all(r["passed"] for r in results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/validate-logic/SKILL.md
+++ b/.claude/skills/validate-logic/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: validate-logic
+description: >
+  L13-L17 類型和邏輯驗證 - 檢查類型一致性、邏輯完整性、錯誤處理、安全性、性能。
+  BlueMouse 17-Layer Validation Group 4（最深層檢查）。
+  Triggers: "logic", "security", "performance", "error handling", "安全檢查"
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+user-invocable: true
+context: fork
+---
+
+# Validate Logic Skill (L13-L17)
+
+BlueMouse 17-Layer Validation System - Group 4: 類型和邏輯驗證（最深層檢查）
+
+## Two Ways to Use
+
+### 1. AI-Guided Validation
+Follow the checklist below to analyze code.
+
+### 2. Script Execution
+```bash
+python3 .claude/skills/validate-logic/validator.py myfile.py
+python3 .claude/skills/validate-logic/validator.py --verbose myfile.py
+```
+
+---
+
+# L13-L17 Validation Checklist
+
+## L13: 類型一致性檢查
+
+**What**: All functions in the code have ≥70% type hint coverage
+
+**How**:
+```python
+funcs = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+total = len(funcs)
+with_hints = sum(
+    1 for f in funcs
+    if f.returns or any(arg.annotation for arg in f.args.args)
+)
+coverage = int(with_hints / total * 100)
+passed = coverage >= 70
+```
+
+**Pass**: `"函數類型提示覆蓋率: {coverage}%"` (≥70%)
+**Fail**: `"函數類型提示覆蓋率: {coverage}%"` (<70%)
+
+---
+
+## L14: 邏輯完整性檢查 (Informational)
+
+**What**: Code has control flow structures
+
+**How**:
+```python
+if_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.If))
+for_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.For))
+while_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.While))
+
+has_branches = (if_count + for_count + while_count) > 0
+```
+
+**Output**:
+- Has control flow: `"邏輯結構完整"`
+- No control flow: `"邏輯結構簡單"`
+
+**Pass**: Always (informational only)
+
+---
+
+## L15: 錯誤處理檢查 ⚠️ ANTI-PATTERN DETECTION
+
+**What**: No empty try-except blocks or pass-only handlers
+
+**How**:
+```python
+try_nodes = [node for node in ast.walk(tree) if isinstance(node, ast.Try)]
+
+bad_handlers = 0
+for node in try_nodes:
+    for handler in node.handlers:
+        # Empty handler
+        if not handler.body:
+            bad_handlers += 1
+        # Only pass statement
+        elif len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass):
+            bad_handlers += 1
+```
+
+**Pass**: Has try-except AND `bad_handlers == 0` → `"檢測到 N 個有效錯誤處理塊"`
+**Fail**:
+- No try-except: `"建議添加 try-except 錯誤處理塊"`
+- Bad handlers: `"發現 N 個空的或只有 pass 的錯誤處理塊 (Anti-pattern)"`
+
+**Examples**:
+```python
+# ❌ FAIL: Empty handler
+try:
+    risky()
+except:
+    pass
+
+# ❌ FAIL: Only pass
+try:
+    risky()
+except Exception as e:
+    pass
+
+# ✅ PASS: Proper handling
+try:
+    risky()
+except Exception as e:
+    logger.error(f"Error: {e}")
+    raise
+```
+
+---
+
+## L16: 安全性檢查 🔒 SECURITY SCAN
+
+**What**: No dangerous functions or hardcoded secrets
+
+### Dangerous Functions
+| Function | Risk | Alternative |
+|----------|------|-------------|
+| `eval()` | Arbitrary code execution | `ast.literal_eval()` |
+| `exec()` | Arbitrary code execution | Avoid |
+| `compile()` | Code injection | Avoid |
+| `__import__()` | Dynamic import risk | Use regular import |
+| `pickle` | Deserialization attack | `json` |
+
+**Detection**:
+```python
+dangerous_funcs = ['eval', 'exec', 'compile', '__import__']
+
+for node in ast.walk(tree):
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name):
+            if node.func.id in dangerous_funcs:
+                issues.append(f"使用了危險函數: {node.func.id}")
+```
+
+### Hardcoded Secrets
+| Pattern | Example |
+|---------|---------|
+| `api_key = "..."` | `api_key = "sk-123456789"` |
+| `password = "..."` | `password = "secret123"` |
+| `secret = "..."` | `secret = "mysecret"` |
+| `token = "..."` | `token = "eyJ..."` |
+| AWS keys | `aws_access_key_id = "AKIA..."` |
+
+**Detection**:
+```python
+secret_patterns = [
+    r'api_key\s*=\s*[\'"][^\s\'\"]{10,}[\'"]',
+    r'password\s*=\s*[\'"][^\s\'\"]{8,}[\'"]',
+    r'secret\s*=\s*[\'"][^\s\'\"]{10,}[\'"]',
+    r'token\s*=\s*[\'"][^\s\'\"]{10,}[\'"]',
+    r'aws_access_key_id\s*=\s*[\'"]AKIA',
+]
+```
+
+**Pass**: `"未發現明顯安全問題"`
+**Fail**: `"發現 N 個潛在安全性問題"` + list issues
+
+**Examples**:
+```python
+# ❌ FAIL: Dangerous function
+result = eval(user_input)
+
+# ❌ FAIL: Hardcoded secret
+api_key = "sk-1234567890abcdef"
+
+# ✅ PASS: Safe alternatives
+import os
+api_key = os.environ.get('API_KEY')
+result = ast.literal_eval(safe_input)
+```
+
+---
+
+## L17: 性能檢查 ⚡ COMPLEXITY ANALYSIS
+
+**What**: No deeply nested loops (≥3 levels)
+
+**How**:
+```python
+def get_loop_depth(node, current_depth=0):
+    max_depth = current_depth
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.For, ast.While)):
+            child_depth = get_loop_depth(child, current_depth + 1)
+        else:
+            child_depth = get_loop_depth(child, current_depth)
+        max_depth = max(max_depth, child_depth)
+    return max_depth
+
+# Find max nesting depth
+for node in ast.walk(tree):
+    if isinstance(node, (ast.For, ast.While)):
+        depth = get_loop_depth(node, 1)
+        max_depth = max(max_depth, depth)
+
+passed = max_depth < 3
+```
+
+**Pass**: `"最高循環嵌套深度: {depth} (符合效能規範)"` (depth < 3)
+**Fail**: `"檢測到過深的循環嵌套 (Depth: {depth})，建議優化算法"` (depth ≥ 3)
+
+**Examples**:
+```python
+# ✅ PASS: 2-level nesting (O(n²))
+for i in range(n):
+    for j in range(n):
+        process(i, j)
+
+# ❌ FAIL: 3-level nesting (O(n³))
+for i in range(n):      # Level 1
+    for j in range(n):  # Level 2
+        for k in range(n):  # Level 3 - TOO DEEP!
+            process(i, j, k)
+```
+
+**Optimization Suggestions**:
+- Use dictionary lookups instead of nested loops
+- Restructure algorithm
+- Use vectorized operations (numpy)
+
+---
+
+## Output Format
+
+```
+==================================================
+L13-L17: 類型和邏輯驗證
+==================================================
+
+Status: ✅ PASSED / ❌ FAILED
+Score: X/100 (N/5 layers)
+
+✅/❌ L13: 類型一致性檢查 - 函數類型提示覆蓋率: X%
+✅ L14: 邏輯完整性檢查 - 邏輯結構完整/簡單
+✅/❌ L15: 錯誤處理檢查 - [message]
+✅/❌ L16: 安全性檢查 - [message]
+✅/❌ L17: 性能檢查 - [message]
+
+[Verbose mode shows detailed issues]
+```
+
+---
+
+## Related Skills
+
+| Skill | Layers |
+|-------|--------|
+| `/validate-17-layers` | L1-L17 (完整) |
+| `/validate-syntax` | L1-L4 |
+| `/validate-signature` | L5-L8 |
+| `/validate-dependencies` | L9-L12 |
+| `/validate-logic` | **L13-L17** |
+
+---
+
+*Part of BlueMouse 17-Layer Validation System*

--- a/.claude/skills/validate-logic/validator.py
+++ b/.claude/skills/validate-logic/validator.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+BlueMouse L13-L17: 類型和邏輯驗證
+獨立版本 - 可作為 Claude Code Skill 使用
+
+用法:
+    python validator.py <file.py>
+    python validator.py --code "def foo(): pass"
+"""
+
+import ast
+import re
+import sys
+import json
+import argparse
+from typing import Dict, List, Optional
+
+
+def validate_types_and_logic(code: str, spec: Optional[Dict] = None) -> List[Dict]:
+    """L13-L17: 類型和邏輯驗證"""
+    results = []
+    results.append(validate_l13_type_consistency(code))
+    results.append(validate_l14_logic_completeness(code))
+    results.append(validate_l15_error_handling(code))
+    results.append(validate_l16_security(code))
+    results.append(validate_l17_performance(code))
+    return results
+
+
+def validate_l13_type_consistency(code: str) -> Dict:
+    """L13: 類型一致性檢查 (AST 深度掃描)"""
+    try:
+        tree = ast.parse(code)
+        funcs = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+        if not funcs:
+            return {"layer": 13, "name": "類型一致性檢查", "passed": True, "message": "無函數需檢查"}
+
+        total = len(funcs)
+        with_hints = sum(1 for f in funcs if f.returns or any(arg.annotation for arg in f.args.args))
+
+        coverage = int(with_hints / total * 100)
+        passed = coverage >= 70
+        return {
+            "layer": 13,
+            "name": "類型一致性檢查",
+            "passed": passed,
+            "message": f"函數類型提示覆蓋率: {coverage}%",
+            "coverage": coverage,
+            "threshold": 70
+        }
+    except Exception as e:
+        return {"layer": 13, "name": "類型一致性檢查", "passed": False, "message": f"分析失敗: {e}"}
+
+
+def validate_l14_logic_completeness(code: str) -> Dict:
+    """L14: 邏輯完整性檢查"""
+    try:
+        tree = ast.parse(code)
+
+        # 統計控制流結構
+        if_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.If))
+        for_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.For))
+        while_count = sum(1 for n in ast.walk(tree) if isinstance(n, ast.While))
+
+        has_branches = (if_count + for_count + while_count) > 0
+
+        return {
+            "layer": 14,
+            "name": "邏輯完整性檢查",
+            "passed": True,
+            "message": "邏輯結構完整" if has_branches else "邏輯結構簡單",
+            "control_flow": {
+                "if": if_count,
+                "for": for_count,
+                "while": while_count
+            }
+        }
+    except Exception as e:
+        return {
+            "layer": 14,
+            "name": "邏輯完整性檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l15_error_handling(code: str) -> Dict:
+    """L15: 錯誤處理檢查 (深度驗證)"""
+    try:
+        tree = ast.parse(code)
+        try_nodes = [node for node in ast.walk(tree) if isinstance(node, ast.Try)]
+
+        if not try_nodes:
+            return {
+                "layer": 15,
+                "name": "錯誤處理檢查",
+                "passed": False,
+                "message": "建議添加 try-except 錯誤處理塊"
+            }
+
+        bad_handlers = 0
+        anti_patterns = []
+        for node in try_nodes:
+            for handler in node.handlers:
+                if not handler.body:
+                    bad_handlers += 1
+                    anti_patterns.append("空的 except 塊")
+                elif len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass):
+                    bad_handlers += 1
+                    anti_patterns.append("except 塊只有 pass")
+
+        if bad_handlers > 0:
+            return {
+                "layer": 15,
+                "name": "錯誤處理檢查",
+                "passed": False,
+                "message": f"發現 {bad_handlers} 個空的或只有 pass 的錯誤處理塊 (Anti-pattern)",
+                "anti_patterns": anti_patterns
+            }
+
+        return {
+            "layer": 15,
+            "name": "錯誤處理檢查",
+            "passed": True,
+            "message": f"檢測到 {len(try_nodes)} 個有效錯誤處理塊"
+        }
+    except Exception as e:
+        return {"layer": 15, "name": "錯誤處理檢查", "passed": False, "message": f"解析失敗: {str(e)}"}
+
+
+def validate_l16_security(code: str) -> Dict:
+    """L16: 安全性檢查 (深度分析)"""
+    try:
+        tree = ast.parse(code)
+        issues = []
+
+        # 危險函數檢測
+        dangerous_funcs = ['eval', 'exec', 'compile', '__import__']
+        dangerous_modules = ['pickle', 'subprocess', 'os.system']
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func_name = ""
+                if isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    func_name = node.func.attr
+
+                if func_name in dangerous_funcs:
+                    issues.append(f"使用了危險函數: {func_name}")
+
+        # 硬編碼秘密檢測
+        secret_patterns = [
+            (r'api_key\s*=\s*[\'"][^\s\'\"]{10,}[\'"]', "API Key"),
+            (r'password\s*=\s*[\'"][^\s\'\"]{8,}[\'"]', "Password"),
+            (r'secret\s*=\s*[\'"][^\s\'\"]{10,}[\'"]', "Secret"),
+            (r'token\s*=\s*[\'"][^\s\'\"]{10,}[\'"]', "Token"),
+            (r'aws_access_key_id\s*=\s*[\'"]AKIA', "AWS Key"),
+        ]
+        for pattern, secret_type in secret_patterns:
+            if re.search(pattern, code, re.IGNORECASE):
+                issues.append(f"檢測到可能的寫死{secret_type}")
+
+        return {
+            "layer": 16,
+            "name": "安全性檢查",
+            "passed": len(issues) == 0,
+            "message": "未發現明顯安全問題" if not issues else f"發現 {len(issues)} 個潛在安全性問題",
+            "issues": issues if issues else None
+        }
+    except Exception as e:
+        return {"layer": 16, "name": "安全性檢查", "passed": False, "message": f"分析失敗: {str(e)}"}
+
+
+def validate_l17_performance(code: str) -> Dict:
+    """L17: 性能檢查 (深度循環分析)"""
+    try:
+        tree = ast.parse(code)
+
+        def get_loop_depth(node, current_depth=0):
+            """遞歸計算循環嵌套深度"""
+            max_depth = current_depth
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.For, ast.While)):
+                    child_depth = get_loop_depth(child, current_depth + 1)
+                    max_depth = max(max_depth, child_depth)
+                else:
+                    child_depth = get_loop_depth(child, current_depth)
+                    max_depth = max(max_depth, child_depth)
+            return max_depth
+
+        max_depth = 0
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.For, ast.While)):
+                depth = get_loop_depth(node, 1)
+                max_depth = max(max_depth, depth)
+
+        if max_depth >= 3:
+            return {
+                "layer": 17,
+                "name": "性能檢查",
+                "passed": False,
+                "message": f"檢測到過深的循環嵌套 (Depth: {max_depth})，建議優化算法",
+                "max_loop_depth": max_depth,
+                "threshold": 3
+            }
+
+        return {
+            "layer": 17,
+            "name": "性能檢查",
+            "passed": True,
+            "message": f"最高循環嵌套深度: {max_depth} (符合效能規範)",
+            "max_loop_depth": max_depth
+        }
+    except Exception as e:
+        return {"layer": 17, "name": "性能檢查", "passed": False, "message": f"分析失敗: {str(e)}"}
+
+
+def print_report(results: List[Dict], verbose: bool = False):
+    """打印驗證報告"""
+    print(f"\n{'='*50}")
+    print("L13-L17: 類型和邏輯驗證")
+    print(f"{'='*50}\n")
+
+    passed_count = sum(1 for r in results if r["passed"])
+    total_count = len(results)
+    score = int((passed_count / total_count) * 100)
+
+    status = "✅ PASSED" if passed_count == total_count else "❌ FAILED"
+    print(f"Status: {status}")
+    print(f"Score: {score}/100 ({passed_count}/{total_count} layers)\n")
+
+    for layer in results:
+        icon = "✅" if layer['passed'] else "❌"
+        print(f"{icon} L{layer['layer']}: {layer['name']} - {layer['message']}")
+        if verbose:
+            if 'issues' in layer and layer['issues']:
+                for issue in layer['issues']:
+                    print(f"    ⚠️  {issue}")
+            if 'anti_patterns' in layer and layer['anti_patterns']:
+                for ap in layer['anti_patterns']:
+                    print(f"    ⚠️  {ap}")
+            if 'control_flow' in layer:
+                cf = layer['control_flow']
+                print(f"    控制流: if={cf['if']}, for={cf['for']}, while={cf['while']}")
+
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='BlueMouse L13-L17: 類型和邏輯驗證')
+    parser.add_argument('file', nargs='?', help='Python file to validate')
+    parser.add_argument('--code', '-c', help='Code string to validate')
+    parser.add_argument('--stdin', action='store_true', help='Read code from stdin')
+    parser.add_argument('--json', '-j', action='store_true', help='Output as JSON')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+
+    args = parser.parse_args()
+
+    code = None
+    if args.stdin:
+        code = sys.stdin.read()
+    elif args.code:
+        code = args.code
+    elif args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                code = f.read()
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    results = validate_types_and_logic(code)
+
+    if args.json:
+        output = {
+            "group": "L13-L17: 類型和邏輯驗證",
+            "passed": all(r["passed"] for r in results),
+            "layers": results,
+            "score": int(sum(1 for r in results if r["passed"]) / len(results) * 100)
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+    else:
+        print_report(results, verbose=args.verbose)
+
+    sys.exit(0 if all(r["passed"] for r in results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/validate-signature/SKILL.md
+++ b/.claude/skills/validate-signature/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: validate-signature
+description: >
+  L5-L8 函數簽名驗證 - 檢查參數、返回值、類型提示、文檔字符串。
+  BlueMouse 17-Layer Validation Group 2。
+  Triggers: "signature", "參數檢查", "type hints", "docstring"
+allowed-tools:
+  - Read
+  - Bash
+user-invocable: true
+context: fork
+---
+
+# Validate Signature Skill (L5-L8)
+
+BlueMouse 17-Layer Validation System - Group 2: 函數簽名驗證
+
+## Two Ways to Use
+
+### 1. AI-Guided Validation
+Follow the checklist below to analyze code.
+
+### 2. Script Execution
+```bash
+python3 .claude/skills/validate-signature/validator.py myfile.py
+python3 .claude/skills/validate-signature/validator.py --spec spec.json myfile.py
+```
+
+---
+
+# L5-L8 Validation Checklist
+
+## L5: 參數檢查
+
+**What**: Function has parameters (or matches spec if provided)
+
+**How**:
+```python
+func = functions[0]  # Check first function
+actual_params = set(arg.arg for arg in func.args.args)
+
+if spec and 'inputs' in spec:
+    expected_params = set(spec['inputs'])
+    passed = expected_params == actual_params
+else:
+    passed = True  # No spec, just report count
+```
+
+**Pass**:
+- With spec: `"參數與規格匹配"`
+- Without spec: `"函數有 N 個參數"`
+
+**Fail**: `"參數不匹配: 期望 {expected}, 實際 {actual}"`
+
+---
+
+## L6: 返回值檢查
+
+**What**: Function has explicit `return` statement
+
+**How**:
+```python
+has_return = any(
+    isinstance(node, ast.Return)
+    for node in ast.walk(func)
+)
+```
+
+**Pass**: `"函數有返回值"`
+**Fail**: `"函數缺少返回值"`
+
+**Examples**:
+```python
+# ✅ PASS
+def process(data):
+    return data * 2
+
+# ❌ FAIL
+def process(data):
+    print(data)  # No return
+```
+
+---
+
+## L7: 類型提示檢查
+
+**What**: Type hints coverage ≥80% AND has return type annotation
+
+**How**:
+```python
+params_with_hints = sum(1 for arg in func.args.args if arg.annotation)
+total_params = len(func.args.args)
+has_return_hint = func.returns is not None
+
+if total_params > 0:
+    coverage = params_with_hints / total_params
+else:
+    coverage = 1.0 if has_return_hint else 0.0
+
+passed = coverage >= 0.8 and has_return_hint
+```
+
+**Pass**: `"類型提示覆蓋率: {coverage}%"`
+**Fail**: `"類型提示不足: {coverage}%"`
+
+**Coverage Examples**:
+| Params | Annotated | Coverage | Return Type | Result |
+|--------|-----------|----------|-------------|--------|
+| 5 | 5 | 100% | ✅ | ✅ PASS |
+| 5 | 4 | 80% | ✅ | ✅ PASS |
+| 5 | 3 | 60% | ✅ | ❌ FAIL |
+| 5 | 5 | 100% | ❌ | ❌ FAIL |
+
+**Examples**:
+```python
+# ✅ PASS: 100% coverage + return type
+def process(data: list, count: int) -> dict:
+    return {}
+
+# ❌ FAIL: Missing return type
+def process(data: list, count: int):
+    return {}
+
+# ❌ FAIL: <80% coverage
+def process(data, count: int) -> dict:  # 50%
+    return {}
+```
+
+---
+
+## L8: 文檔字符串檢查
+
+**What**: Function has meaningful docstring (>10 characters)
+
+**How**:
+```python
+docstring = ast.get_docstring(func)
+passed = docstring and len(docstring) > 10
+```
+
+**Pass**: `"有完整文檔字符串 ({length} 字符)"`
+**Fail**: `"缺少或文檔字符串過短"`
+
+**Examples**:
+```python
+# ✅ PASS: >10 characters
+def process(data):
+    """Process input data and return results."""
+    return data
+
+# ❌ FAIL: Too short (≤10 chars)
+def process(data):
+    """Process"""
+    return data
+
+# ❌ FAIL: No docstring
+def process(data):
+    return data
+```
+
+---
+
+## Output Format
+
+```
+==================================================
+L5-L8: 函數簽名驗證
+==================================================
+
+Status: ✅ PASSED / ❌ FAILED
+Score: X/100 (N/4 layers)
+
+✅/❌ L5: 參數檢查 - [message]
+✅/❌ L6: 返回值檢查 - [message]
+✅/❌ L7: 類型提示檢查 - [message]
+✅/❌ L8: 文檔字符串檢查 - [message]
+```
+
+---
+
+## Related Skills
+
+| Skill | Layers |
+|-------|--------|
+| `/validate-17-layers` | L1-L17 (完整) |
+| `/validate-syntax` | L1-L4 |
+| `/validate-signature` | **L5-L8** |
+| `/validate-dependencies` | L9-L12 |
+| `/validate-logic` | L13-L17 |
+
+---
+
+*Part of BlueMouse 17-Layer Validation System*

--- a/.claude/skills/validate-signature/validator.py
+++ b/.claude/skills/validate-signature/validator.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+BlueMouse L5-L8: 函數簽名驗證
+獨立版本 - 可作為 Claude Code Skill 使用
+
+用法:
+    python validator.py <file.py>
+    python validator.py --code "def foo(): pass"
+    python validator.py --spec spec.json <file.py>
+"""
+
+import ast
+import sys
+import json
+import argparse
+from typing import Dict, List, Optional
+
+
+def validate_function_signature(code: str, spec: Optional[Dict] = None) -> List[Dict]:
+    """L5-L8: 函數簽名驗證"""
+    results = []
+    results.append(validate_l5_parameters(code, spec))
+    results.append(validate_l6_return_value(code, spec))
+    results.append(validate_l7_type_hints(code))
+    results.append(validate_l8_docstring(code))
+    return results
+
+
+def validate_l5_parameters(code: str, spec: Optional[Dict]) -> Dict:
+    """L5: 參數檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 5,
+                "name": "參數檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+
+        if spec and 'inputs' in spec:
+            expected_params = set(spec['inputs'])
+            actual_params = set(arg.arg for arg in func.args.args)
+
+            if expected_params == actual_params:
+                return {
+                    "layer": 5,
+                    "name": "參數檢查",
+                    "passed": True,
+                    "message": "參數與規格匹配"
+                }
+            else:
+                return {
+                    "layer": 5,
+                    "name": "參數檢查",
+                    "passed": False,
+                    "message": f"參數不匹配: 期望 {expected_params}, 實際 {actual_params}"
+                }
+        else:
+            return {
+                "layer": 5,
+                "name": "參數檢查",
+                "passed": True,
+                "message": f"函數有 {len(func.args.args)} 個參數"
+            }
+    except Exception as e:
+        return {
+            "layer": 5,
+            "name": "參數檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l6_return_value(code: str, spec: Optional[Dict]) -> Dict:
+    """L6: 返回值檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        has_return = any(isinstance(node, ast.Return) for node in ast.walk(func))
+
+        if has_return:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": True,
+                "message": "函數有返回值"
+            }
+        else:
+            return {
+                "layer": 6,
+                "name": "返回值檢查",
+                "passed": False,
+                "message": "函數缺少返回值"
+            }
+    except Exception as e:
+        return {
+            "layer": 6,
+            "name": "返回值檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l7_type_hints(code: str) -> Dict:
+    """L7: 類型提示檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        params_with_hints = sum(1 for arg in func.args.args if arg.annotation)
+        total_params = len(func.args.args)
+        has_return_hint = func.returns is not None
+
+        if total_params > 0:
+            hint_coverage = params_with_hints / total_params
+        else:
+            hint_coverage = 1.0 if has_return_hint else 0.0
+
+        if hint_coverage >= 0.8 and has_return_hint:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": True,
+                "message": f"類型提示覆蓋率: {hint_coverage*100:.0f}%"
+            }
+        else:
+            return {
+                "layer": 7,
+                "name": "類型提示檢查",
+                "passed": False,
+                "message": f"類型提示不足: {hint_coverage*100:.0f}%"
+            }
+    except Exception as e:
+        return {
+            "layer": 7,
+            "name": "類型提示檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def validate_l8_docstring(code: str) -> Dict:
+    """L8: 文檔字符串檢查"""
+    try:
+        tree = ast.parse(code)
+        functions = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+
+        if not functions:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": False,
+                "message": "未找到函數定義"
+            }
+
+        func = functions[0]
+        docstring = ast.get_docstring(func)
+
+        if docstring and len(docstring) > 10:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": True,
+                "message": f"有完整文檔字符串 ({len(docstring)} 字符)"
+            }
+        else:
+            return {
+                "layer": 8,
+                "name": "文檔字符串檢查",
+                "passed": False,
+                "message": "缺少或文檔字符串過短"
+            }
+    except Exception as e:
+        return {
+            "layer": 8,
+            "name": "文檔字符串檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def print_report(results: List[Dict], verbose: bool = False):
+    """打印驗證報告"""
+    print(f"\n{'='*50}")
+    print("L5-L8: 函數簽名驗證")
+    print(f"{'='*50}\n")
+
+    passed_count = sum(1 for r in results if r["passed"])
+    total_count = len(results)
+    score = int((passed_count / total_count) * 100)
+
+    status = "✅ PASSED" if passed_count == total_count else "❌ FAILED"
+    print(f"Status: {status}")
+    print(f"Score: {score}/100 ({passed_count}/{total_count} layers)\n")
+
+    for layer in results:
+        icon = "✅" if layer['passed'] else "❌"
+        print(f"{icon} L{layer['layer']}: {layer['name']} - {layer['message']}")
+
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='BlueMouse L5-L8: 函數簽名驗證')
+    parser.add_argument('file', nargs='?', help='Python file to validate')
+    parser.add_argument('--code', '-c', help='Code string to validate')
+    parser.add_argument('--stdin', action='store_true', help='Read code from stdin')
+    parser.add_argument('--json', '-j', action='store_true', help='Output as JSON')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+    parser.add_argument('--spec', '-s', help='JSON spec file for validation')
+
+    args = parser.parse_args()
+
+    code = None
+    if args.stdin:
+        code = sys.stdin.read()
+    elif args.code:
+        code = args.code
+    elif args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                code = f.read()
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    spec = None
+    if args.spec:
+        try:
+            with open(args.spec, 'r', encoding='utf-8') as f:
+                spec = json.load(f)
+        except Exception as e:
+            print(f"Warning: Could not load spec file: {e}", file=sys.stderr)
+
+    results = validate_function_signature(code, spec)
+
+    if args.json:
+        output = {
+            "group": "L5-L8: 函數簽名驗證",
+            "passed": all(r["passed"] for r in results),
+            "layers": results,
+            "score": int(sum(1 for r in results if r["passed"]) / len(results) * 100)
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+    else:
+        print_report(results, verbose=args.verbose)
+
+    sys.exit(0 if all(r["passed"] for r in results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/validate-syntax/SKILL.md
+++ b/.claude/skills/validate-syntax/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: validate-syntax
+description: >
+  L1-L4 語法和結構驗證 - 檢查 Python 語法、AST 結構、縮進格式、命名規範。
+  BlueMouse 17-Layer Validation Group 1。
+  Triggers: "syntax", "格式檢查", "naming", "PEP8"
+allowed-tools:
+  - Read
+  - Bash
+user-invocable: true
+context: fork
+---
+
+# Validate Syntax Skill (L1-L4)
+
+BlueMouse 17-Layer Validation System - Group 1: 語法和結構驗證
+
+## Two Ways to Use
+
+### 1. AI-Guided Validation
+Follow the checklist below to analyze code.
+
+### 2. Script Execution
+```bash
+python3 .claude/skills/validate-syntax/validator.py myfile.py
+python3 .claude/skills/validate-syntax/validator.py --json myfile.py
+```
+
+---
+
+# L1-L4 Validation Checklist
+
+## L1: 基本語法檢查
+
+**What**: Code compiles without syntax errors
+
+**How**:
+```python
+compile(code, '<string>', 'exec')
+```
+
+**Pass**: No SyntaxError raised
+**Fail**: Report error: `"語法錯誤: {error_message}"`
+
+---
+
+## L2: AST 結構檢查
+
+**What**: Code contains at least one function or class definition
+
+**How**:
+```python
+tree = ast.parse(code)
+has_definition = any(
+    isinstance(node, (ast.FunctionDef, ast.ClassDef))
+    for node in ast.walk(tree)
+)
+```
+
+**Pass**: `has_definition == True`
+**Fail**: `"缺少函數或類定義"`
+
+---
+
+## L3: 縮進和格式檢查
+
+**What**: Proper indentation format
+
+**Rules**:
+1. No tab characters (`\t`) anywhere
+2. Leading spaces must be multiples of 4
+
+**How**:
+```python
+for i, line in enumerate(lines, 1):
+    if '\t' in line:
+        issues.append(f"Line {i}: 使用 Tab 而非空格")
+    leading_spaces = len(line) - len(line.lstrip())
+    if leading_spaces % 4 != 0:
+        issues.append(f"Line {i}: 縮進不是 4 的倍數")
+```
+
+**Pass**: No issues found
+**Fail**: `"發現 N 個格式問題"` + list first 3 issues
+
+**Examples**:
+```python
+# ✅ PASS: 4-space indentation
+def foo():
+    if True:
+        return 1
+
+# ❌ FAIL: Tab character
+def foo():
+	return 1  # Uses tab
+
+# ❌ FAIL: 2-space indentation
+def foo():
+  return 1  # 2 spaces, not multiple of 4
+```
+
+---
+
+## L4: 命名規範檢查
+
+**What**: PEP 8 naming conventions
+
+**Rules**:
+| Type | Convention | Regex |
+|------|------------|-------|
+| Functions | snake_case | `^[a-z_][a-z0-9_]*$` |
+| Classes | PascalCase | `^[A-Z][a-zA-Z0-9]*$` |
+
+**How**:
+```python
+for node in ast.walk(tree):
+    if isinstance(node, ast.FunctionDef):
+        if not re.match(r'^[a-z_][a-z0-9_]*$', node.name):
+            issues.append(f"函數名 '{node.name}' 不符合 snake_case")
+    if isinstance(node, ast.ClassDef):
+        if not re.match(r'^[A-Z][a-zA-Z0-9]*$', node.name):
+            issues.append(f"類名 '{node.name}' 不符合 PascalCase")
+```
+
+**Pass**: All names follow conventions → `"命名符合 PEP 8"`
+**Fail**: `"發現 N 個命名問題"` + list issues
+
+**Examples**:
+```python
+# ✅ PASS
+def calculate_total():  # snake_case
+    pass
+
+class UserManager:  # PascalCase
+    pass
+
+# ❌ FAIL
+def CalculateTotal():  # Should be snake_case
+    pass
+
+class user_manager:  # Should be PascalCase
+    pass
+```
+
+---
+
+## Output Format
+
+```
+==================================================
+L1-L4: 語法和結構驗證
+==================================================
+
+Status: ✅ PASSED / ❌ FAILED
+Score: X/100 (N/4 layers)
+
+✅/❌ L1: 基本語法檢查 - [message]
+✅/❌ L2: AST 結構檢查 - [message]
+✅/❌ L3: 縮進和格式檢查 - [message]
+✅/❌ L4: 命名規範檢查 - [message]
+```
+
+---
+
+## Related Skills
+
+| Skill | Layers |
+|-------|--------|
+| `/validate-17-layers` | L1-L17 (完整) |
+| `/validate-syntax` | **L1-L4** |
+| `/validate-signature` | L5-L8 |
+| `/validate-dependencies` | L9-L12 |
+| `/validate-logic` | L13-L17 |
+
+---
+
+*Part of BlueMouse 17-Layer Validation System*

--- a/.claude/skills/validate-syntax/validator.py
+++ b/.claude/skills/validate-syntax/validator.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+BlueMouse L1-L4: 語法和結構驗證
+獨立版本 - 可作為 Claude Code Skill 使用
+
+用法:
+    python validator.py <file.py>
+    python validator.py --code "def foo(): pass"
+"""
+
+import ast
+import re
+import sys
+import json
+import argparse
+from typing import Dict, List
+
+
+def validate_syntax_and_structure(code: str) -> List[Dict]:
+    """L1-L4: 語法和結構驗證"""
+    results = []
+    results.append(validate_l1_basic_syntax(code))
+    results.append(validate_l2_ast_structure(code))
+    results.append(validate_l3_indentation(code))
+    results.append(validate_l4_naming_convention(code))
+    return results
+
+
+def validate_l1_basic_syntax(code: str) -> Dict:
+    """L1: 基本語法檢查"""
+    try:
+        compile(code, '<string>', 'exec')
+        return {
+            "layer": 1,
+            "name": "基本語法檢查",
+            "passed": True,
+            "message": "語法正確"
+        }
+    except SyntaxError as e:
+        return {
+            "layer": 1,
+            "name": "基本語法檢查",
+            "passed": False,
+            "message": f"語法錯誤: {str(e)}",
+            "error": str(e)
+        }
+
+
+def validate_l2_ast_structure(code: str) -> Dict:
+    """L2: AST 結構檢查"""
+    try:
+        tree = ast.parse(code)
+        has_definition = any(isinstance(node, (ast.FunctionDef, ast.ClassDef))
+                            for node in ast.walk(tree))
+
+        if has_definition:
+            return {
+                "layer": 2,
+                "name": "AST 結構檢查",
+                "passed": True,
+                "message": "AST 結構完整"
+            }
+        else:
+            return {
+                "layer": 2,
+                "name": "AST 結構檢查",
+                "passed": False,
+                "message": "缺少函數或類定義"
+            }
+    except Exception as e:
+        return {
+            "layer": 2,
+            "name": "AST 結構檢查",
+            "passed": False,
+            "message": f"AST 解析失敗: {str(e)}"
+        }
+
+
+def validate_l3_indentation(code: str) -> Dict:
+    """L3: 縮進和格式檢查"""
+    lines = code.split('\n')
+    issues = []
+
+    for i, line in enumerate(lines, 1):
+        if '\t' in line:
+            issues.append(f"Line {i}: 使用 Tab 而非空格")
+
+        if line and not line.lstrip():
+            continue
+        leading_spaces = len(line) - len(line.lstrip())
+        if leading_spaces % 4 != 0:
+            issues.append(f"Line {i}: 縮進不是 4 的倍數")
+
+    if not issues:
+        return {
+            "layer": 3,
+            "name": "縮進和格式檢查",
+            "passed": True,
+            "message": "縮進格式正確"
+        }
+    else:
+        return {
+            "layer": 3,
+            "name": "縮進和格式檢查",
+            "passed": False,
+            "message": f"發現 {len(issues)} 個格式問題",
+            "issues": issues[:3]
+        }
+
+
+def validate_l4_naming_convention(code: str) -> Dict:
+    """L4: 命名規範檢查 (PEP 8)"""
+    try:
+        tree = ast.parse(code)
+        issues = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                if not re.match(r'^[a-z_][a-z0-9_]*$', node.name):
+                    issues.append(f"函數名 '{node.name}' 不符合 snake_case")
+
+            if isinstance(node, ast.ClassDef):
+                if not re.match(r'^[A-Z][a-zA-Z0-9]*$', node.name):
+                    issues.append(f"類名 '{node.name}' 不符合 PascalCase")
+
+        if not issues:
+            return {
+                "layer": 4,
+                "name": "命名規範檢查",
+                "passed": True,
+                "message": "命名符合 PEP 8"
+            }
+        else:
+            return {
+                "layer": 4,
+                "name": "命名規範檢查",
+                "passed": len(issues) == 0,
+                "message": f"發現 {len(issues)} 個命名問題",
+                "issues": issues[:3]
+            }
+    except Exception as e:
+        return {
+            "layer": 4,
+            "name": "命名規範檢查",
+            "passed": False,
+            "message": f"檢查失敗: {str(e)}"
+        }
+
+
+def print_report(results: List[Dict], verbose: bool = False):
+    """打印驗證報告"""
+    print(f"\n{'='*50}")
+    print("L1-L4: 語法和結構驗證")
+    print(f"{'='*50}\n")
+
+    passed_count = sum(1 for r in results if r["passed"])
+    total_count = len(results)
+    score = int((passed_count / total_count) * 100)
+
+    status = "✅ PASSED" if passed_count == total_count else "❌ FAILED"
+    print(f"Status: {status}")
+    print(f"Score: {score}/100 ({passed_count}/{total_count} layers)\n")
+
+    for layer in results:
+        icon = "✅" if layer['passed'] else "❌"
+        print(f"{icon} L{layer['layer']}: {layer['name']} - {layer['message']}")
+        if verbose and 'issues' in layer and layer['issues']:
+            for issue in layer['issues']:
+                print(f"    → {issue}")
+
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='BlueMouse L1-L4: 語法和結構驗證')
+    parser.add_argument('file', nargs='?', help='Python file to validate')
+    parser.add_argument('--code', '-c', help='Code string to validate')
+    parser.add_argument('--stdin', action='store_true', help='Read code from stdin')
+    parser.add_argument('--json', '-j', action='store_true', help='Output as JSON')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+
+    args = parser.parse_args()
+
+    code = None
+    if args.stdin:
+        code = sys.stdin.read()
+    elif args.code:
+        code = args.code
+    elif args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                code = f.read()
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    results = validate_syntax_and_structure(code)
+
+    if args.json:
+        output = {
+            "group": "L1-L4: 語法和結構驗證",
+            "passed": all(r["passed"] for r in results),
+            "layers": results,
+            "score": int(sum(1 for r in results if r["passed"]) / len(results) * 100)
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+    else:
+        print_report(results, verbose=args.verbose)
+
+    sys.exit(0 if all(r["passed"] for r in results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- 將專案中的 `validation_17_layers.py` 驗證邏輯抽取為獨立的 Claude Code Skills
- 支援雙向使用：AI 指導驗證 + 腳本執行
- 完全獨立，可複製到任何專案使用

## 新增 Skills

| Skill | Layers | 用途 |
|-------|--------|------|
| `validate-17-layers` | L1-L17 | 完整驗證（主入口） |
| `validate-syntax` | L1-L4 | 語法和結構驗證 |
| `validate-signature` | L5-L8 | 函數簽名驗證 |
| `validate-dependencies` | L9-L12 | 依賴關係驗證 |
| `validate-logic` | L13-L17 | 類型和邏輯驗證 |

## 使用方式

### AI 指導驗證
AI 讀取 SKILL.md 中的 Checklist，按規則分析代碼

### 腳本執行
```bash
python3 .claude/skills/validate-17-layers/validator.py myfile.py
python3 .claude/skills/validate-17-layers/validator.py --json myfile.py
```

## 特點

- ✅ 零外部依賴（只用 Python 標準庫）
- ✅ 可複製到任何專案或 `~/.claude/skills/` 全域使用
- ✅ SKILL.md 提供完整的 17 層檢查規則說明
- ✅ validator.py 提供命令行執行和 CI/CD 整合

## Test plan

- [x] 測試 validator.py 對正確代碼返回 100/100
- [x] 測試 validator.py 對問題代碼正確檢測各層失敗

🤖 Generated with [Claude Code](https://claude.com/claude-code)